### PR TITLE
fix: enabling the usage of an action of type list

### DIFF
--- a/pkg_blender/blendtorch/btb/env.py
+++ b/pkg_blender/blendtorch/btb/env.py
@@ -1,6 +1,7 @@
 import bpy
 import zmq
 import sys
+import numpy as np
 
 from .animation import AnimationController
 from .offscreen import OffScreenRenderer
@@ -103,7 +104,7 @@ class BaseEnv:
             if cmd == BaseEnv.CMD_RESTART:
                 self._restart()
             elif cmd == BaseEnv.CMD_STEP:
-                if action != None:
+                if np.all(action != None):
                     self._env_prepare_step(action)
                     self.ctx['prev_action'] = action
                 self.state = BaseEnv.STATE_RUN


### PR DESCRIPTION
Hi,

we found out that there is an issue with the action variable. If it is a list instead of an int or float, it raises an error [here](https://github.com/cheind/pytorch-blender/blob/eb5effb033094d037e7bdc2238c00806be7012ae/pkg_blender/blendtorch/btb/env.py#L106). 

We fixed it by adding np.all() to check for None elements independently of the variable type.