### PR TITLE
Update __init__.py to work setuptools

### DIFF
--- a/pkg_pytorch/blendtorch/btt/__init__.py
+++ b/pkg_pytorch/blendtorch/btt/__init__.py
@@ -8,4 +8,4 @@ from .duplex import DuplexChannel
 from . import env
 from . import colors
 
-__version__ = "0.4.0"
+__version__ = 0.4.0


### PR DESCRIPTION
removed quotes from version number, as it was failing to install due to incompatibility with my setuptools version (the one that came with python3.11, also tried with python 3.7)

system: ubuntu